### PR TITLE
CFURL and CFAttributedString patches for TextEdit

### DIFF
--- a/CFAttributedString.c
+++ b/CFAttributedString.c
@@ -83,7 +83,7 @@ static __CFRunArrayItem * _CFRunArrayItemInit(CFRange range, CFDictionaryRef dic
 {
     __CFRunArrayItem *obj = (__CFRunArrayItem *)malloc(sizeof(__CFRunArrayItem));
     obj->_range = range;
-    obj->_dictionary = CFRetain(dict);
+    obj->_dictionary = CFDictionaryCreateCopy(kCFAllocatorDefault, dict);
     return obj;
 }
 


### PR DESCRIPTION
Adds Type Identification to CFURl(and by extension NSURL) using the LaunchServices `UTTypeCreatePreferredIdentifierForTag(...)` API.