### PR TITLE
Add ARM64 (aarch64) build support for Darling on Linux

### DIFF
--- a/CFForwardingPrep.S
+++ b/CFForwardingPrep.S
@@ -323,6 +323,100 @@ __CF_forwarding_prep_b:
 
     .cfi_endproc
 
+#elif defined(__arm64__) || defined(__aarch64__)
+
+.section __TEXT,__text,regular,pure_instructions
+.globl __CF_forwarding_prep_0
+.globl __CF_forwarding_prep_1
+.p2align 2
+
+__CF_forwarding_prep_0:
+__CF_forwarding_prep_1:
+    // Save frame and link register
+    stp x29, x30, [sp, #-16]!
+    mov x29, sp
+
+    // Allocate space for register save area (128) + return value (32)
+    sub sp, sp, #160
+
+    // Save integer register arguments at sp+0
+    stp x0, x1, [sp, #0]
+    stp x2, x3, [sp, #16]
+    stp x4, x5, [sp, #32]
+    stp x6, x7, [sp, #48]
+
+    // Save floating-point register arguments at sp+64
+    stp d0, d1, [sp, #64]
+    stp d2, d3, [sp, #80]
+    stp d4, d5, [sp, #96]
+    stp d6, d7, [sp, #112]
+
+    // Call ____forwarding___(marg_list, return_stret_addr)
+    mov x0, sp             // marg_list
+    add x1, sp, #128       // return value storage
+    bl  ____forwarding___
+
+    cbnz x0, Lfail_arm64   // non-nil means we have a forwarding target
+
+    // Load return values from on-stack storage
+    ldr x0, [sp, #128]
+    ldr d0, [sp, #128]
+
+    mov sp, x29
+    ldp x29, x30, [sp], #16
+    ret
+
+Lfail_arm64:
+    // x0 is the forwarding target (new self)
+    // Restore all other args and restart message send
+    mov x9, x0             // save forwarding target
+
+    ldp d0, d1, [sp, #64]
+    ldp d2, d3, [sp, #80]
+    ldp d4, d5, [sp, #96]
+    ldp d6, d7, [sp, #112]
+
+    // Restore integer args (x0 = new target, skip original x0)
+    ldr x1, [sp, #8]
+    ldp x2, x3, [sp, #16]
+    ldp x4, x5, [sp, #32]
+    ldp x6, x7, [sp, #48]
+
+    mov x0, x9             // new self
+
+    mov sp, x29
+    ldp x29, x30, [sp], #16
+
+    b   _objc_msgSend      // restart message send with new target
+
+.globl __CF_forwarding_prep_b
+.p2align 2
+
+__CF_forwarding_prep_b:
+    stp x29, x30, [sp, #-16]!
+    mov x29, sp
+
+    sub sp, sp, #128
+
+    // Save integer register arguments
+    stp x0, x1, [sp, #0]
+    stp x2, x3, [sp, #16]
+    stp x4, x5, [sp, #32]
+    stp x6, x7, [sp, #48]
+
+    // Save floating-point register arguments
+    stp d0, d1, [sp, #64]
+    stp d2, d3, [sp, #80]
+    stp d4, d5, [sp, #96]
+    stp d6, d7, [sp, #112]
+
+    mov x0, sp
+    bl  ___block_forwarding__
+
+    mov sp, x29
+    ldp x29, x30, [sp], #16
+    ret
+
 #else
-#error Missing forwarding prep handlers for this arch https://code.google.com/p/apportable/issues/detail?id=619
+#error Missing forwarding prep handlers for this arch
 #endif

--- a/CFRuntime.c
+++ b/CFRuntime.c
@@ -1169,8 +1169,8 @@ void __CFInitialize(void) {
         clsArray = objc_lookUpClass("NSArray");
         selAlloc = sel_registerName("alloc");
         selInit = sel_registerName("init");
-        __NSDictionary0__ = objc_msgSend(objc_msgSend(clsDict, selAlloc), selInit);
-        __NSArray0__ = objc_msgSend(objc_msgSend(clsArray, selAlloc), selInit);
+        __NSDictionary0__ = ((id (*)(id, SEL))objc_msgSend)(((id (*)(id, SEL))objc_msgSend)(clsDict, selAlloc), selInit);
+        __NSArray0__ = ((id (*)(id, SEL))objc_msgSend)(((id (*)(id, SEL))objc_msgSend)(clsArray, selAlloc), selInit);
 
         __CFInitializing = 0;
         __CFInitialized = 1;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,11 @@ set_property(TARGET CoreFoundation_x86_64 APPEND_STRING PROPERTY
   LINK_FLAGS " -Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/reexport_x86_64.exp \
 	-Wl,-alias,_OBJC_CLASS_\\$___NSCFConstantString,___CFConstantStringClassReference")
 endif (TARGET_x86_64)
+if (TARGET_ARM64)
+set_property(TARGET CoreFoundation_arm64 APPEND_STRING PROPERTY
+  LINK_FLAGS " -Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/reexport_arm64.exp \
+	-Wl,-alias,_OBJC_CLASS_\\$___NSCFConstantString,___CFConstantStringClassReference")
+endif (TARGET_ARM64)
 
 set_source_files_properties(${cf_c_sources} PROPERTIES COMPILE_FLAGS "-x objective-c")
 

--- a/NSInvoke-x86.S
+++ b/NSInvoke-x86.S
@@ -81,7 +81,7 @@ Ldone:
   pop %ebp
   ret
 
-#else // Now the x86-64 version
+#elif defined(__x86_64__) // Now the x86-64 version
 
   .cfi_startproc
   .cfi_personality 155, ___objc_personality_v0
@@ -154,6 +154,101 @@ Ldone:
   // .cfi_def_cfa rsp, 8
   ret
   .cfi_endproc
+#elif defined(__arm64__) || defined(__aarch64__)
+
+// ARM64 __invoke__
+// x0 = msgSend function pointer
+// x1 = retdata pointer
+// x2 = args (marg_list)
+// x3 = frame_length
+// x4 = return_type
+//
+// marg_list layout for ARM64:
+//   bytes 0-63:   x0-x7 integer/pointer register args (8 * 8 bytes)
+//   bytes 64-127: d0-d7 floating-point register args (8 * 8 bytes)
+//   bytes 128+:   stack-passed arguments
+
+  stp x29, x30, [sp, #-16]!
+  mov x29, sp
+  stp x19, x20, [sp, #-16]!
+  stp x21, x22, [sp, #-16]!
+
+  mov x19, x0    // x19 = msgSend function pointer
+  mov x20, x1    // x20 = retdata pointer
+  mov x21, x4    // x21 = return_type
+  mov x22, x2    // x22 = args pointer (saved so we can load x2 as argument)
+
+  // Copy stack arguments if frame_length > 128
+  cmp x3, #128
+  b.le Lno_stack_args_arm64
+
+  sub x9, x3, #128     // number of stack arg bytes
+  // Align stack allocation to 16 bytes
+  add x9, x9, #15
+  and x9, x9, #-16
+  sub sp, sp, x9
+
+  // Copy stack args
+  add x10, x22, #128   // source = args + 128
+  mov x11, sp           // dest = sp
+  sub x12, x3, #128    // remaining bytes
+Lcopy_loop_arm64:
+  ldr x13, [x10], #8
+  str x13, [x11], #8
+  subs x12, x12, #8
+  b.gt Lcopy_loop_arm64
+
+Lno_stack_args_arm64:
+  // Load floating-point register arguments from args
+  ldp d0, d1, [x22, #64]
+  ldp d2, d3, [x22, #80]
+  ldp d4, d5, [x22, #96]
+  ldp d6, d7, [x22, #112]
+
+  // Load integer register arguments from args
+  // Load x2 from its slot since x22 holds the args pointer
+  ldp x6, x7, [x22, #48]
+  ldp x4, x5, [x22, #32]
+  ldr x3, [x22, #24]
+  ldr x2, [x22, #16]
+  ldr x1, [x22, #8]
+  ldr x0, [x22, #0]
+
+  // Call the function
+  blr x19
+
+  // Store return value based on return type
+  ldrb w9, [x21]
+
+  // Always store integer return value
+  str x0, [x20]
+  str x1, [x20, #8]
+
+  // Check for float/double return types
+  cmp w9, #0x66        // 'f' = float
+  b.eq Lfloatret_arm64
+  cmp w9, #0x64        // 'd' = double
+  b.eq Ldoubleret_arm64
+  cmp w9, #0x44        // 'D' = long double (== double on ARM64)
+  b.eq Ldoubleret_arm64
+  b Ldone_arm64
+
+Lfloatret_arm64:
+  str s0, [x20]
+  b Ldone_arm64
+
+Ldoubleret_arm64:
+  str d0, [x20]
+
+Ldone_arm64:
+  mov sp, x29
+  ldp x21, x22, [sp, #-32]
+  ldp x19, x20, [sp, #-16]
+  ldp x29, x30, [sp], #16
+  ret
+
+#else
+#error Unsupported architecture for NSInvoke
 #endif
 
 

--- a/reexport_arm64.exp
+++ b/reexport_arm64.exp
@@ -1,0 +1,3 @@
+_OBJC_CLASS_$_NSObject
+_OBJC_IVAR_$_NSObject.isa
+_OBJC_METACLASS_$_NSObject


### PR DESCRIPTION
Per-package ARM64 (aarch64) build adjustments so this submodule compiles cleanly under a Linux aarch64 host. Part of the ARM64 support series; the umbrella PR in `darlinghq/darling` references the rest.